### PR TITLE
Improve file name normalization

### DIFF
--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -253,8 +253,9 @@ end
 function runner.real_name(filename)
    local orig_filename = filename
    -- Normalize file names before using patterns.
-   filename = filename:gsub("\\", "/"):gsub("%.lua$", "")
-
+   filename = filename:gsub("\\", "/")    -- normalize separators
+               :gsub("%.lua$", "")        -- remove file extension
+               :gsub("^%./", "")          -- remove "same directory" prefix
    for i, pattern in ipairs(runner.modules.patterns) do
       local match = filename:match(pattern)
 

--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -251,16 +251,18 @@ end
 -- using `luacov.defaults.modules` option.
 -- @param filename name of the file.
 function runner.real_name(filename)
-   local orig_filename = filename
+   -- remove "same directory" prefix
+   filename = filename:gsub("^%./", "")
+   local new_filename = filename
+
    -- Normalize file names before using patterns.
-   filename = filename:gsub("\\", "/")    -- normalize separators
-               :gsub("%.lua$", "")        -- remove file extension
-               :gsub("^%./", "")          -- remove "same directory" prefix
+   filename = filename:gsub("\\", "/")       -- normalize separators
+                      :gsub("%.lua$", "")    -- remove file extension
    for i, pattern in ipairs(runner.modules.patterns) do
       local match = filename:match(pattern)
 
       if match then
-         local new_filename = runner.modules.filenames[i]
+         new_filename = runner.modules.filenames[i]
 
          if pattern:find(wildcard_expansion, 1, true) then
             -- Given a prefix directory, join it
@@ -272,12 +274,12 @@ function runner.real_name(filename)
             new_filename = new_filename .. match .. ".lua"
          end
 
-         -- Switch slashes back to native.
-         return (new_filename:gsub("^%.[/\\]", ""):gsub("[/\\]", dir_sep))
+         break
       end
    end
 
-   return orig_filename
+   -- Switch slashes back to native.
+   return (new_filename:gsub("^%.[/\\]", ""):gsub("[/\\]", dir_sep))
 end
 
 -- Always exclude luacov's own files.

--- a/src/luacov/stats.lua
+++ b/src/luacov/stats.lua
@@ -30,6 +30,9 @@ function stats.load(statsfile)
       if not filename then
          break
       end
+
+       -- strip trailing white spaces
+      filename = filename:match('(.*)%s*$')
       data[filename] = {
          max = max,
          max_hits = 0


### PR DESCRIPTION
I encountered a couple of problems when running `luacov` in a Linux and Windows mixed environment:

1. stats files generated on Windows contain CRs that end appended to filenames generating warnings and errors when loading the stats file;
2. stats files sometimes contain the same file name more than once, some times as `a/b/c`, other times as `./a/b/c` causing an incorrect calculation of the coverage.

This PR addresses those two problems with the following changes:

1. trailing space is stripped from file names when loading the stats file;
2. `real_name` strips the `./` prefix from the input file name.