### PR TITLE
allow stuff like 'end end end' as an unaccounted line

### DIFF
--- a/src/luacov/linescanner.lua
+++ b/src/luacov/linescanner.lua
@@ -39,7 +39,7 @@ end
 --- Lines that are always excluded from accounting
 local any_hits_exclusions = {
    "", -- Empty line
-   "end[,; %)]*", -- Single "end"
+   "end[,; %)]*[end[,; %)]*]*", -- One or more "end"s
    "else", -- Single "else"
    "repeat", -- Single "repeat"
    "do", -- Single "do"


### PR DESCRIPTION
As a matter of subjective preference, I like to write lines like
```
end end end
```
where others might write
```
    end
  end
end
```
but this doesn't seem to jive with this rule.

Can we change it to allow multiple `end`s?

P.S.  Thank you so much for your work on this!  It's really valuable to me.