### PR TITLE
Adding `nameparser` configuration entry.

### DIFF
--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -73,4 +73,14 @@ return {
   -- Default: false.
   includeuntestedfiles = false,
 
+  --- Provides a function to parse filenames.
+  -- This function is used to parse filenames in the debug hook.
+  -- It is passed the filename as an argument and should return the parsed filename.
+  -- The default parser removes leading `@` and replaces path separators with `/`.
+  -- @usage
+  -- nameparser = function(name)
+  --    return name:match("^@?(.*)")
+  -- end
+  nameparser = nil
+
 }

--- a/src/luacov/hook.lua
+++ b/src/luacov/hook.lua
@@ -30,8 +30,12 @@ function hook.new(runner)
       -- Get name of processed file.
       local name = debug.getinfo(level, "S").source
       local prefixed_name = string.match(name, "^@(.*)")
+      local name_parser = runner.configuration.nameparser
+      local parsed_name = name_parser and name_parser(name)
       if prefixed_name then
          name = prefixed_name:gsub("^%.[/\\]", ""):gsub("[/\\]", dir_sep)
+      elseif parsed_name then
+         name = parsed_name:gsub("^%.[/\\]", ""):gsub("[/\\]", dir_sep)
       elseif not runner.configuration.codefromstrings then
          -- Ignore Lua code loaded from raw strings by default.
          return

--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -528,6 +528,10 @@ local function getsourcefile(func)
    if d and d:sub(1, 1) == "@" then
       return d:sub(2)
    end
+   local name_parser = runner.configuration.nameparser
+   if d and name_parser then
+      return name_parser(d)
+   end
 end
 
 -- Looks for a function inside a table.


### PR DESCRIPTION
When embedding Lua into binary, it isn't uncommon to also package Lua files into the final product. There will usually be a custom loader to read the source files from the packaged files.

In order to maintain functionality of luacov in such circumstances, this PR provides a mechanism for the user to provide custom mappings between internal names and an external source location.

For example, if the custom file loader prefixes its files with `src:`, we can do something like the following:

```lua
configuration = {
  nameparser = function(name)
    if name:sub(1, 4) == 'src:' then
      return '/location/of/debug/files/' .. name:sub(5)
    end
  end
}
```